### PR TITLE
[TASK] Remove requirement for comments to be on a new line

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -22,7 +22,6 @@
 
 	<!-- Commenting -->
 	<rule ref="PEAR.Commenting.InlineComment" />
-	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/DoubleSlashCommentsInNewLineSniff.php" />
 	<rule ref="../TYPO3SniffPool/Sniffs/Commenting/SpaceAfterDoubleSlashSniff.php" />
 
 	<!-- Control structures -->


### PR DESCRIPTION
We do not require comments to be on a new line, like we for example
allow the following:

```
[
	[NULL, 110, NULL, NULL, 110, 82],	// maximum width respects aspect ratio
	[NULL, 110, NULL, 80, 106, 80],		// maximum height wins
]
```